### PR TITLE
Update counter validation logic to align to Webauthn spec

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -550,7 +550,7 @@ async function validateCounter() {
     var prevCounter = this.expectations.get("prevCounter");
     var counter = this.authnrData.get("counter");
 
-    if (counter <= prevCounter) {
+    if (counter <= prevCounter && (counter != 0 || prevCounter != 0)) {
         throw new Error("counter rollback detected");
     }
 


### PR DESCRIPTION
The Webauthn specification states that counter validation should only occur if authenticator signCount is nonzero, or the stored counter is nonzero. See step 17 of §7.2: https://www.w3.org/TR/webauthn/#verifying-assertion